### PR TITLE
remove state lifting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import {useAtom, useAtomValue} from "jotai";
-import {IParams} from "./interfaces.ts";
+import {useAtomValue, useSetAtom} from "jotai";
 import {actualWorkflowAtom, selectedStepAtom, actualStepNumberAtom} from "./atoms.ts";
 import {BuilderComponent} from "./BuilderComponent.tsx";
 import {ConfigType1} from "./tooltypes/type1/ConfigType1.tsx";
@@ -9,12 +8,8 @@ import {ConfigType3} from "./tooltypes/type3/ConfigType3.tsx";
 function App() {
 
   const actualWorkflow = useAtomValue(actualWorkflowAtom)
-  const [actualStep, setActualStep] = useAtom(selectedStepAtom)
-  const [actualStepNumber, setActualStepNumber] = useAtom(actualStepNumberAtom)
-
-  const updateParamsHandler = (params:IParams) => {
-    setActualStep({...actualStep, params: params})
-  }
+  const actualStep = useAtomValue(selectedStepAtom)
+  const setActualStepNumber = useSetAtom(actualStepNumberAtom)
 
   const updateSelectedHandler = (selected:number) => {
     setActualStepNumber(selected-1)
@@ -23,11 +18,11 @@ function App() {
   const actualStepParams = () => {
     switch (actualStep.toolType) {
       case 1:
-        return <ConfigType1 configParams={actualStep.params} handleUpdateParams={updateParamsHandler}/>
+        return <ConfigType1 />
       case 2:
-        return <ConfigType2 configParams={actualStep.params} handleUpdateParams={updateParamsHandler}/>
+        return <ConfigType2 toolId={actualStep.id}/>
       case 3:
-        return <ConfigType3 configParams={actualStep.params} handleUpdateParams={updateParamsHandler}/>
+        return <ConfigType3 />
       default:
         return <div>ToolType {actualStep.toolType} not implemented</div>
     }
@@ -42,7 +37,7 @@ function App() {
         </div>
         <div className="col-5">
           <h1>Config</h1>
-          <div>Selected: {actualStepNumber}</div>
+          <div>Selected: {actualStep.name}</div>
           {actualStepParams()}
         </div>
       </div>

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,5 +1,5 @@
 import {atom} from "jotai";
-import {IStep, IWorkflow} from "./interfaces.ts";
+import {IParams, IStep, IWorkflow} from "./interfaces.ts";
 
 
 export const actualStepNumberAtom = atom<number>(0)
@@ -7,16 +7,23 @@ export const actualStepNumberAtom = atom<number>(0)
 export const actualWorkflowAtom = atom<IWorkflow>({
   steps: [
     {id: 1, toolType: 1, name: 'tool1', params: {param1: 'tool1, type1', ed1: 'config1ed1', filePath: 'one.txt'}},
-    {id: 2, toolType: 2, name: 'tool2', params: {param2: 'tool2, type2', ed1: 'config2ed1', filePath: 'two.xml'}},
+    {id: 2, toolType: 2, name: 'tool2', params: {param2: 'tool2, type2', ed1: '', filePath: 'two.xml', anotherParam: 'anotherParam'}},
     {id: 3, toolType: 3, name: 'tool3', params: {param3: 'tool3, type3', ed1: 'config3ed1'}},
     {id: 4, toolType: 2, name: 'tool4', params: {param2: 'tool4, type2', ed1: 'config4ed1', filePath: 'four.xml'}},
+    {id: 5, toolType: 1, name: 'tool5', params: {param1: 'tool5, type1', ed1: 'config5ed1', filePath: 'five without extension'}},
   ]
 })
 
-// @ts-ignore
 export const selectedStepAtom = atom<IStep>(
   (get) => get(actualWorkflowAtom).steps[get(actualStepNumberAtom)],
   (get, set, update) => {
     set(actualWorkflowAtom, {steps: get(actualWorkflowAtom).steps.map((step, index) => index === get(actualStepNumberAtom) ? update : step)})
+  }
+)
+
+export const selectedParamsAtom = atom<IParams>(
+  get => get(selectedStepAtom).params,
+  (get, set, updatedParams) => {
+    set(selectedStepAtom, {...get(selectedStepAtom), params: updatedParams})
   }
 )

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,17 @@
+
 export interface IParams {
-  [key: string]: any
+  [key: string]: any|undefined
+}
+
+export interface ITouchedDictionary {
+  [key: string]: boolean
 }
 
 export interface IStep {
   id: number
   toolType: number
   name: string
+  touched: ITouchedDictionary
   params: IParams
 }
 

--- a/src/tooltypes/type1/ConfigType1.tsx
+++ b/src/tooltypes/type1/ConfigType1.tsx
@@ -1,38 +1,37 @@
 import {useFormik} from "formik";
-import {IParams} from "../../interfaces.ts";
 import {ToolType1Schema} from "./validation.ts";
 import * as Yup from "yup";
+import {useAtom} from "jotai";
+import {selectedStepAtom} from "../../atoms.ts";
+import {DisplayFormikState} from "../type2/display-formik-state.tsx";
 
-interface IConfigProps {
-  configParams: IParams,
-  handleUpdateParams: (params: IParams) => void
-}
+export function ConfigType1() {
 
-export function ConfigType1({configParams, handleUpdateParams}: IConfigProps) {
+  const [selectedStep, setSelectedStep] = useAtom(selectedStepAtom)
 
   const formik = useFormik({
-    initialValues: configParams,
+    initialValues: selectedStep.params,
+    initialTouched: selectedStep.touched,
     validationSchema: Yup.object().shape(ToolType1Schema()),
     enableReinitialize: true,
     validateOnMount: true,
-    validateOnBlur: true,
     onSubmit: () => {},
   });
 
-  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleUpdateParams({...formik.values, [e.target.name]: e.target.value})
-  };
-
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    formik.handleBlur(e)
-    handleTextChange(e)
+    formik.setFieldTouched(e.target.name, true, true)
+    setSelectedStep({
+      ...selectedStep,
+      touched: formik.touched,
+      params: {...formik.values, [e.target.name]: e.target.value}
+    })
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('handleChange', e.target.name, e.target.value)
     formik.setFieldTouched(e.target.name, true, true)
     formik.handleChange(e)
   }
+
 
   return (
     <>
@@ -41,30 +40,28 @@ export function ConfigType1({configParams, handleUpdateParams}: IConfigProps) {
         Param1
         <input name="param1" type="text" className="form-control" value={formik.values['param1']}
                onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors['param1'] && (
-          <div className="text-danger">{formik.errors['param1']}</div>
+        {formik.errors.param1 && formik.touched.param1 && (
+          <div className="text-danger">{formik.errors.param1}</div>
         )}
       </div>
       <div className="mt-2">
         ed1
         <input name="ed1" type="text" className="form-control" value={formik.values['ed1']}
                onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors['ed1'] && (
-          <div className="text-danger">{formik.errors['ed1']}</div>
+        {formik.errors.ed1 && formik.touched.ed1 && (
+          <div className="text-danger">{formik.errors.ed1}</div>
         )}
       </div>
       <div className="mt-2">
         filePath
         <input name="filePath" type="text" className="form-control" value={formik.values.filePath}
                onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.filePath && (
+        {formik.errors.filePath && formik.touched.filePath && (
           <div className="text-danger">{formik.errors.filePath}</div>
         )}
       </div>
-      <div>
-        <div>Values: {JSON.stringify(formik.values)}</div>
-        <div>Errors: {JSON.stringify(formik.errors)}</div>
-        <div>Touched: {JSON.stringify(formik.touched)}</div>
+      <div className="mt-4">
+        <DisplayFormikState formik={formik} />
       </div>
     </>
   )

--- a/src/tooltypes/type2/ConfigType2.tsx
+++ b/src/tooltypes/type2/ConfigType2.tsx
@@ -1,34 +1,33 @@
 import {useFormik} from "formik";
-import {IParams} from "../../interfaces.ts";
 import {ToolType2Schema} from "./validation.ts";
 import * as Yup from "yup";
+import {useAtom} from "jotai/index";
+import {selectedStepAtom} from "../../atoms.ts";
+import ValidatedControl from "../../validated-control.tsx";
+import {DisplayFormikState} from "./display-formik-state.tsx";
 
-interface IConfigProps {
-  configParams: IParams,
-  handleUpdateParams: (params: IParams) => void
-}
 
-export function ConfigType2({configParams, handleUpdateParams}: IConfigProps) {
+export function ConfigType2() {
+
+  const [selectedStep, setSelectedStep] = useAtom(selectedStepAtom)
 
   const formik = useFormik({
-    initialValues: configParams,
+    initialValues: selectedStep.params,
     validationSchema: Yup.object().shape(ToolType2Schema()),
+    initialTouched: selectedStep.touched,
     enableReinitialize: true,
     validateOnMount: true,
-    validateOnBlur: true,
-    onSubmit: values => {
-      alert(JSON.stringify(values, null, 2));
-      handleUpdateParams(values)
+    onSubmit: () => {
     },
   });
 
-  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleUpdateParams({...formik.values, [e.target.name]: e.target.value})
-  };
-
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    formik.handleBlur(e)
-    handleTextChange(e)
+    formik.setFieldTouched(e.target.name, true, true)
+    setSelectedStep({
+      ...selectedStep,
+      touched: formik.touched,
+      params: {...formik.values, [e.target.name]: e.target.value}
+    })
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -41,33 +40,32 @@ export function ConfigType2({configParams, handleUpdateParams}: IConfigProps) {
       <h3>ToolType2 parameters</h3>
 
       <div>
-        Param2
-        <input name="param2" type="text" className="form-control" value={formik.values.param2}
-               onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.param2 && (
-          <div className="text-danger">{formik.errors.param2}</div>
-        )}
+        <ValidatedControl name="param2" formik={formik} title="Param2">
+          <input name="param2" type="text" className="form-control" value={formik.values.param2}
+                 onChange={handleChange} onBlur={handleBlur}/>
+
+        </ValidatedControl>
       </div>
       <div className="mt-2">
-        ed1
-        <input name="ed1" type="text" className="form-control" value={formik.values.ed1}
-               onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.ed1 && (
-          <div className="text-danger">{formik.errors.ed1}</div>
-        )}
+        <ValidatedControl name="ed1" formik={formik} title="Ed1">
+          <input name="ed1" type="text" className="form-control" value={formik.values.ed1}
+                 onChange={handleChange} onBlur={handleBlur}/>
+        </ValidatedControl>
       </div>
       <div className="mt-2">
-        filePath
-        <input name="filePath" type="text" className="form-control" value={formik.values.filePath}
-               onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.filePath && (
-          <div className="text-danger">{formik.errors.filePath}</div>
-        )}
+        <ValidatedControl name="filePath" formik={formik} title="File path">
+          <input name="filePath" type="text" className="form-control" value={formik.values.filePath}
+                 onChange={handleChange} onBlur={handleBlur}/>
+        </ValidatedControl>
       </div>
-      <div>
-        <div>Values: {JSON.stringify(formik.values)}</div>
-        <div>Errors: {JSON.stringify(formik.errors)}</div>
-        <div>Touched: {JSON.stringify(formik.touched)}</div>
+      <div className="mt-2">
+        <ValidatedControl name="anotherParam" formik={formik} title="Another param">
+          <input name="anotherParam" type="text" className="form-control" value={formik.values.anotherParam}
+                 onChange={handleChange} onBlur={handleBlur}/>
+          </ValidatedControl>
+      </div>
+      <div className="mt-4">
+        <DisplayFormikState formik={formik}/>
       </div>
     </>
   )

--- a/src/tooltypes/type2/display-formik-state.tsx
+++ b/src/tooltypes/type2/display-formik-state.tsx
@@ -1,0 +1,7 @@
+export function DisplayFormikState({formik}) {
+  return <>
+    <div>Values: {JSON.stringify(formik.values)}</div>
+    <div>Errors: {JSON.stringify(formik.errors)}</div>
+    <div>Touched: {JSON.stringify(formik.touched)}</div>
+  </>;
+}

--- a/src/tooltypes/type2/validation.ts
+++ b/src/tooltypes/type2/validation.ts
@@ -1,7 +1,7 @@
 import * as Yup from 'yup';
 
 export const ToolType2Schema = () => ({
-  name: Yup.string().required('Name is required'),
+  param2: Yup.string().required('param2 is required'),
   ed1: Yup.string().required('ed1 is required').max(10, 'ed1 can only be up to 10 characters.'),
   filePath: Yup.string()
     .trim()

--- a/src/tooltypes/type3/ConfigType3.tsx
+++ b/src/tooltypes/type3/ConfigType3.tsx
@@ -1,34 +1,31 @@
 import {useFormik} from "formik";
-import {IParams} from "../../interfaces.ts";
 import {ToolType3Schema} from "./validation.ts";
 import * as Yup from "yup";
+import {useAtom} from "jotai/index";
+import {selectedParamsAtom, selectedStepAtom} from "../../atoms.ts";
+import {DisplayFormikState} from "../type2/display-formik-state.tsx";
 
-interface IConfigProps {
-  configParams: IParams,
-  handleUpdateParams: (params: IParams) => void
-}
 
-export function ConfigType3({configParams, handleUpdateParams}: IConfigProps) {
+export function ConfigType3() {
+
+  const [selectedStep, setSelectedStep] = useAtom(selectedStepAtom)
 
   const formik = useFormik({
-    initialValues: configParams,
+    initialValues: selectedStep.params,
+    initialTouched: selectedStep.touched,
     validationSchema: Yup.object().shape(ToolType3Schema()),
     enableReinitialize: true,
     validateOnMount: true,
-    validateOnBlur: true,
-    onSubmit: values => {
-      alert(JSON.stringify(values, null, 2));
-      handleUpdateParams(values)
-    },
+    onSubmit: () => {},
   });
 
-  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleUpdateParams({...formik.values, [e.target.name]: e.target.value})
-  };
-
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    formik.handleBlur(e)
-    handleTextChange(e)
+    formik.setFieldTouched(e.target.name, true, true)
+    setSelectedStep({
+      ...selectedStep,
+      touched: formik.touched,
+      params: {...formik.values, [e.target.name]: e.target.value}
+    })
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +41,7 @@ export function ConfigType3({configParams, handleUpdateParams}: IConfigProps) {
         Param3
         <input name="param3" type="text" className="form-control" value={formik.values.param3}
                onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.param3 && (
+        {formik.errors.param3 && formik.touched.param3 && (
           <div className="text-danger">{formik.errors.param3}</div>
         )}
       </div>
@@ -52,14 +49,12 @@ export function ConfigType3({configParams, handleUpdateParams}: IConfigProps) {
         ed1
         <input name="ed1" type="text" className="form-control" value={formik.values.ed1}
                onChange={handleChange} onBlur={handleBlur}/>
-        {formik.errors.ed1 && (
+        {formik.errors.ed1 && formik.touched.ed1 && (
           <div className="text-danger">{formik.errors.ed1}</div>
         )}
       </div>
-      <div>
-        <div>Values: {JSON.stringify(formik.values)}</div>
-        <div>Errors: {JSON.stringify(formik.errors)}</div>
-        <div>Touched: {JSON.stringify(formik.touched)}</div>
+      <div className="mt-4">
+        <DisplayFormikState formik={formik} />
       </div>
     </>
   )

--- a/src/tooltypes/type3/validation.ts
+++ b/src/tooltypes/type3/validation.ts
@@ -1,7 +1,6 @@
 import * as Yup from 'yup';
 
 export const ToolType3Schema = () => ({
-  name: Yup.string().required('Name is required'),
   ed1: Yup.string().required('ed1 is required').max(10, 'ed1 can only be up to 10 characters.'),
   filePath: Yup.string()
     .trim()

--- a/src/validated-control.tsx
+++ b/src/validated-control.tsx
@@ -1,0 +1,16 @@
+export default function ValidatedControl({children, name, formik, title}) {
+
+  return (
+    <>
+      {title}
+      {children}
+      {name && (
+        <>
+          {formik.errors[name] && formik.touched[name] && (
+            <div className="text-danger">{formik.errors[name]}</div>
+          )}
+        </>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
removed state lifting: atoms are set on the config components. Storing the initial touched state for reinitialization. Added wrapper control in config2 to avoid repetition
